### PR TITLE
Remove byte order character before parsing description as md.

### DIFF
--- a/tasks/components/scraper.js
+++ b/tasks/components/scraper.js
@@ -175,12 +175,12 @@
 
         component.description = marked(
             isFile
-            ? fs.readFileSync(basepath + description, Scraper.OPTIONS.readFileSync)
+            ? fs.readFileSync(basepath + description, Scraper.OPTIONS.readFileSync).replace(/^\uFEFF/, '')
             : description
         );
 
         return component;
-    }
+    };
 
     /**
      * Add the provided component to the


### PR DESCRIPTION
This PR uses string.replace with a regex to strip leading BOM character from description files before parsing as Markdown. The character was causing issues with the Markdown parser recognizing # heading syntax on a file's first line.

In the observed situation, it's likely the character was added by VS/TFS.

The commit also adds a semicolon that was missing from the containing function assignment (line 183).
